### PR TITLE
Host permitidos  y orígenes de confianza CSRF

### DIFF
--- a/src/backend/settings/production.py
+++ b/src/backend/settings/production.py
@@ -8,7 +8,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = [config('URL_TEST'), config('URL_SERVER')]
 
-CSRF_TRUSTED_ORIGINS = [config('URL_SERVER')]
+CSRF_TRUSTED_ORIGINS = [f'https://{config("URL_SERVER")}']
 
 
 # Database


### PR DESCRIPTION
### Descripción de los Cambios

Se corrigió un error en las variables de configuración ALLOWED_HOSTS y  CSRF_TRUSTED_ORIGINS, que afectaban el despliegue del entorno de desarrollo.